### PR TITLE
Expose core PAL modelling classes at package root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@
 # Jobs:
 # - static-analysis: Runs linting/type checking on Python 3.13
 # - test: Runs pytest with coverage on Python 3.11 through 3.15 (matrix)
-# - docs-math: Builds the documentation and validates rendered mathematics
+# - docs-math: Builds the documentation, tests documentation code blocks, and validates rendered mathematics
 # - build: Builds Python packages using standard build tool
 # - pypi-publish: Publishes to PyPI using trusted publishing (release only)
 #
@@ -107,7 +107,10 @@ jobs:
           node-version: "24"
 
       - name: Install documentation dependencies
-        run: pip install -e ".[docs]"
+        run: pip install -e ".[docs,test]"
+
+      - name: Test documentation code blocks
+        run: pytest docs --codeblocks -q
 
       - name: Install Chrome for Plotly static export
         run: plotly_get_chrome -y
@@ -190,7 +193,7 @@ jobs:
   pypi-publish:
     runs-on: ubuntu-latest
     needs: build
-    # Only publish to PyPI when a GitHub Release is created
+    # Only publish to PyPI using trusted publishing (release only)
     if: github.event_name == 'release'
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@
 #
 # Jobs:
 # - static-analysis: Runs linting/type checking on Python 3.13
-# - test: Runs pytest with coverage on Python 3.11 through 3.15 (matrix), including documentation code blocks
+# - test: Runs pytest with coverage on Python 3.11 through 3.15 (matrix)
 # - docs-math: Builds the documentation and validates rendered mathematics
 # - build: Builds Python packages using standard build tool
 # - pypi-publish: Publishes to PyPI using trusted publishing (release only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@
 #
 # Jobs:
 # - static-analysis: Runs linting/type checking on Python 3.13
-# - test: Runs pytest with coverage on Python 3.11 through 3.15 (matrix)
-# - docs-math: Builds the documentation, tests documentation code blocks, and validates rendered mathematics
+# - test: Runs pytest with coverage on Python 3.11 through 3.15 (matrix), including documentation code blocks
+# - docs-math: Builds the documentation and validates rendered mathematics
 # - build: Builds Python packages using standard build tool
 # - pypi-publish: Publishes to PyPI using trusted publishing (release only)
 #
@@ -107,10 +107,7 @@ jobs:
           node-version: "24"
 
       - name: Install documentation dependencies
-        run: pip install -e ".[docs,test]"
-
-      - name: Test documentation code blocks
-        run: pytest docs --codeblocks -q
+        run: pip install -e ".[docs]"
 
       - name: Install Chrome for Plotly static export
         run: plotly_get_chrome -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
   pypi-publish:
     runs-on: ubuntu-latest
     needs: build
-    # Only publish to PyPI using trusted publishing (release only)
+    # Only publish to PyPI when a GitHub Release is created
     if: github.event_name == 'release'
     permissions:
       id-token: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Tool-specific instruction files should point here rather than duplicate these ru
 
 PAL is a Python library for simulation-based actuarial and financial modelling. It provides stochastic variables, probability distributions, copulas, frequency-severity models, reinsurance contracts, risk measures and optional CuPy GPU acceleration.
 
-The installed package is `pal`; the PyPI distribution is `proteusllp-actuarial-library`.
+The installed package is `pal`; the PyPI distribution is `proteusllp-actuarial-library`. PAL intentionally exposes the four core modelling abstractions `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and `FrequencySeverityModel` at the package root; domain-specific modelling classes remain organised under their public submodules.
 
 ## Sources of Truth
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ A change is complete when:
 
 - Preserve backwards compatibility unless the task explicitly changes the public API.
 - Prefer small, focused changes over broad rewrites.
+- Before changing existing prose, comments or examples, understand their purpose in the surrounding section and preserve that purpose unless the task genuinely requires it to change.
+- Review changes from the perspective of the eventual user or maintainer, not only from the perspective of the implementation task. Do not make surrounding text narrate a refactor or API move when that detail is not useful to its audience.
 - Do not leave comments describing deleted or superseded code.
 - Keep imports at module scope unless there is a documented architectural reason not to.
 - Use type annotations for public interfaces; do not duplicate type information in docstrings.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,6 +19,8 @@ Avoid exposing internal implementation language in user-facing descriptions when
 
 Prefer small canonical examples that demonstrate one concept clearly. Documentation code should use the public API a normal PAL user should copy.
 
+Use top-level imports for PAL's four core modelling abstractions: `from pal import ProteusVariable, StochasticScalar, FreqSevSims, FrequencySeverityModel`. Continue to import domain-specific classes such as distributions, copulas and contracts directly from their documented submodules rather than flattening them into `pal`.
+
 Executable code blocks should remain compatible with `pytest-codeblocks`. Each fenced block is executed independently by default. If a block deliberately relies on imports, variables or other state established by an earlier block, place `<!--pytest-codeblocks:cont-->` immediately before it so the sequence is tested in one shared namespace.
 
 Use `<!--pytest-codeblocks:skip-->` only when a block is intentionally non-executable in the test environment, such as illustrative development shell commands, external-resource examples, interactive display or unavailable hardware. Do not skip a user-facing example merely to make CI green; make executable examples self-contained or use `cont` as appropriate. Be especially careful with shell blocks in repository guidance because `pytest-codeblocks` can execute them and accidentally make the test suite slow or recursive.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,6 +8,10 @@ Write for actuaries, quantitative analysts and Python users. Explain what a publ
 
 Avoid exposing internal implementation language in user-facing descriptions when it does not help the user. In particular, do not describe ordinary operations in terms of "backend ndarrays", internal wrapper machinery or coupling metadata unless that mechanism is itself the topic of the documentation.
 
+When modifying existing documentation, first identify the purpose of the surrounding sentence, paragraph and section from the reader's perspective. Preserve useful existing explanations unless the task requires them to change. A change to an API, import path or implementation detail should not cause unrelated conceptual prose to be rewritten around that change.
+
+Review edited prose as part of the whole document, not only as a description of the current code change. Remove task-centric wording such as discussion of what is "exposed", "re-exported", "moved" or "now available" when a user only needs to know what an object represents and how to use it. Prefer the smallest wording change that keeps the document accurate and natural.
+
 ## Mathematical Documentation
 
 - Keep formulas consistent with the implemented parameterisation.
@@ -49,6 +53,6 @@ Public docstrings should cover:
 
 ## Validation
 
-Build documentation with warnings treated seriously. Run `pytest docs --codeblocks` after changing examples or public API documentation; CI also runs this explicitly so executable examples across the documentation cannot silently fall out of the normal test suite.
+Build documentation with warnings treated seriously. Run the documentation code-block tests after changing examples or public API documentation. The normal CI test matrix runs `pytest` with `--codeblocks`, so executable documentation examples are covered there.
 
 The AI quick reference at `docs/source/ai_assistants.md` is intentionally concise and should remain a high-density map from common user intentions to canonical PAL API usage.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,7 +19,9 @@ Avoid exposing internal implementation language in user-facing descriptions when
 
 Prefer small canonical examples that demonstrate one concept clearly. Documentation code should use the public API a normal PAL user should copy.
 
-Use top-level imports for PAL's four core modelling abstractions: `from pal import ProteusVariable, StochasticScalar, FreqSevSims, FrequencySeverityModel`. Continue to import domain-specific classes such as distributions, copulas and contracts directly from their documented submodules rather than flattening them into `pal`.
+Introduce classes and modelling concepts by explaining what they represent and why a user would use them. Import-path guidance is secondary and should not replace the conceptual introduction.
+
+Use top-level imports for PAL's four core modelling abstractions: `from pal import ProteusVariable, StochasticScalar, FreqSevSims, FrequencySeverityModel`. Continue to import domain-specific classes such as distributions, copulas and contracts directly from their documented submodules rather than flattening them into `pal`. When an example uses top-level configuration helpers such as `config` or `set_random_seed`, make sure those names are imported in the executable block or in the continuation chain on which it relies.
 
 Executable code blocks should remain compatible with `pytest-codeblocks`. Each fenced block is executed independently by default. If a block deliberately relies on imports, variables or other state established by an earlier block, place `<!--pytest-codeblocks:cont-->` immediately before it so the sequence is tested in one shared namespace.
 
@@ -47,6 +49,6 @@ Public docstrings should cover:
 
 ## Validation
 
-Build documentation with warnings treated seriously. Also run relevant documentation code-block tests after changing examples or public API documentation.
+Build documentation with warnings treated seriously. Run `pytest docs --codeblocks` after changing examples or public API documentation; CI also runs this explicitly so executable examples across the documentation cannot silently fall out of the normal test suite.
 
 The AI quick reference at `docs/source/ai_assistants.md` is intentionally concise and should remain a high-density map from common user intentions to canonical PAL API usage.

--- a/docs/source/ai_assistants.md
+++ b/docs/source/ai_assistants.md
@@ -16,8 +16,6 @@ from pal.distributions import Gamma, LogNormal, Poisson
 
 The PyPI distribution is `proteusllp-actuarial-library`; the installed Python package is `pal`.
 
-PAL deliberately exposes four core modelling abstractions at the package root: `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and `FrequencySeverityModel`. Prefer `from pal import ...` for these types. Domain-specific modelling classes remain imported directly from their public submodules, for example `from pal.distributions import Gamma` and `from pal.copulas import GaussianCopula`.
-
 ## Configure simulations
 
 <!--pytest-codeblocks:cont-->
@@ -167,8 +165,6 @@ Useful conceptual guides are:
 
 ## Common mistakes to avoid
 
-- Do not flatten domain-specific modelling APIs into `pal`. The deliberate top-level modelling exports are `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and `FrequencySeverityModel`; distributions, copulas, contracts and other domain classes should still come from their documented submodules.
-- Prefer top-level imports for the four core abstractions in new user-facing code, while their existing submodule import paths remain supported.
 - Do not assume similarly named distributions use the same parameterisation as SciPy or another library; inspect PAL's signature and docstring.
 - Do not discard coupling relationships by extracting and rebuilding raw arrays without a reason.
 - Do not assume two generated risks are dependent until a dependence structure has been applied; derived variables, however, remain aligned with their inputs.

--- a/docs/source/ai_assistants.md
+++ b/docs/source/ai_assistants.md
@@ -9,16 +9,14 @@ pip install proteusllp-actuarial-library
 ```
 
 ```python
-from pal import config, set_random_seed
+from pal import FrequencySeverityModel, ProteusVariable, StochasticScalar, config, set_random_seed
 from pal.copulas import GaussianCopula
 from pal.distributions import Gamma, LogNormal, Poisson
-from pal.frequency_severity import FrequencySeverityModel
-from pal.variables import ProteusVariable, StochasticScalar
 ```
 
 The PyPI distribution is `proteusllp-actuarial-library`; the installed Python package is `pal`.
 
-PAL modelling classes are imported directly from their public submodules. Prefer `from pal.distributions import Gamma`, `from pal.copulas import GaussianCopula`, and `from pal.frequency_severity import FrequencySeverityModel`, then use `Gamma`, `GaussianCopula`, and `FrequencySeverityModel` directly. Core variable types are imported from `pal.variables`.
+PAL deliberately exposes four core modelling abstractions at the package root: `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and `FrequencySeverityModel`. Prefer `from pal import ...` for these types. Domain-specific modelling classes remain imported directly from their public submodules, for example `from pal.distributions import Gamma` and `from pal.copulas import GaussianCopula`.
 
 ## Configure simulations
 
@@ -140,7 +138,7 @@ from pal import api
 api.search("gamma")
 api.search("tail dependence")
 api.describe("pal.distributions.Gamma")
-api.describe("pal.variables.StochasticScalar")
+api.describe("pal.StochasticScalar")
 ```
 
 For ordinary Python introspection, documented public objects also work naturally:
@@ -148,8 +146,8 @@ For ordinary Python introspection, documented public objects also work naturally
 ```python
 import inspect
 
+from pal import StochasticScalar
 from pal.distributions import Gamma
-from pal.variables import StochasticScalar
 
 print(inspect.signature(Gamma))
 help(Gamma)
@@ -169,8 +167,8 @@ Useful conceptual guides are:
 
 ## Common mistakes to avoid
 
-- Do not import modelling classes directly from `pal`, and do not import a modelling submodule just to qualify every class name. Import the class or function directly from its documented `pal.<module>` submodule.
-- Do not import `StochasticScalar` from `pal.stochastic_scalar`; `pal.variables` is its public home.
+- Do not flatten domain-specific modelling APIs into `pal`. The deliberate top-level modelling exports are `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and `FrequencySeverityModel`; distributions, copulas, contracts and other domain classes should still come from their documented submodules.
+- Prefer top-level imports for the four core abstractions in new user-facing code, while their existing submodule import paths remain supported.
 - Do not assume similarly named distributions use the same parameterisation as SciPy or another library; inspect PAL's signature and docstring.
 - Do not discard coupling relationships by extracting and rebuilding raw arrays without a reason.
 - Do not assume two generated risks are dependent until a dependence structure has been applied; derived variables, however, remain aligned with their inputs.

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -31,7 +31,7 @@ lognormal_var = LogNormal(mu=1, sigma=0.5).generate()
 
 ## Variable Containers
 
-A `ProteusVariable` groups related values under a named dimension. It is useful for structures such as lines of business, regions or risk types, and PAL aligns labelled entries when containers are combined in calculations.
+Variables can be grouped into containers with the `ProteusVariable` class:
 
 ```python
 from pal import ProteusVariable

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -6,7 +6,7 @@ This guide provides comprehensive examples of using the Proteus Actuarial Librar
 
 ### Basic Stochastic Variables
 
-A `StochasticScalar` represents one simulated scalar value in each Monte Carlo simulation. It is the basic simulation-level variable in PAL: arithmetic operates scenario by scenario, and methods such as `mean()`, `std()` and `percentile()` summarise the simulated distribution.
+A `StochasticScalar` is a vector of simulated values:
 
 ```python
 from pal import StochasticScalar
@@ -14,8 +14,6 @@ from pal import StochasticScalar
 # Create from array
 svariable = StochasticScalar([1, 2, 3, 4])
 ```
-
-In normal modelling code you will usually obtain a `StochasticScalar` by generating simulations from a distribution rather than constructing one directly.
 
 ### Statistical Distributions
 

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -6,10 +6,10 @@ This guide provides comprehensive examples of using the Proteus Actuarial Librar
 
 ### Basic Stochastic Variables
 
-Stochastic variables can be created with the `StochasticScalar` class from `pal.variables`:
+`StochasticScalar` is one of PAL's core top-level modelling types:
 
 ```python
-from pal.variables import StochasticScalar
+from pal import StochasticScalar
 
 # Create from array
 svariable = StochasticScalar([1, 2, 3, 4])
@@ -31,11 +31,11 @@ lognormal_var = LogNormal(mu=1, sigma=0.5).generate()
 
 ## Variable Containers
 
-Variables can be grouped into containers with the `ProteusVariable` class from `pal.variables`:
+`ProteusVariable` is also exposed directly from `pal`:
 
 ```python
+from pal import ProteusVariable
 from pal.distributions import Gamma, LogNormal
-from pal.variables import ProteusVariable
 
 # Create individual variables
 motor_losses = Gamma(alpha=2.5, theta=2).generate()

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -6,7 +6,7 @@ This guide provides comprehensive examples of using the Proteus Actuarial Librar
 
 ### Basic Stochastic Variables
 
-`StochasticScalar` is one of PAL's core top-level modelling types:
+A `StochasticScalar` represents one simulated scalar value in each Monte Carlo simulation. It is the basic simulation-level variable in PAL: arithmetic operates scenario by scenario, and methods such as `mean()`, `std()` and `percentile()` summarise the simulated distribution.
 
 ```python
 from pal import StochasticScalar
@@ -14,6 +14,8 @@ from pal import StochasticScalar
 # Create from array
 svariable = StochasticScalar([1, 2, 3, 4])
 ```
+
+In normal modelling code you will usually obtain a `StochasticScalar` by generating simulations from a distribution rather than constructing one directly.
 
 ### Statistical Distributions
 
@@ -31,7 +33,7 @@ lognormal_var = LogNormal(mu=1, sigma=0.5).generate()
 
 ## Variable Containers
 
-`ProteusVariable` is also exposed directly from `pal`:
+A `ProteusVariable` groups related values under a named dimension. It is useful for structures such as lines of business, regions or risk types, and PAL aligns labelled entries when containers are combined in calculations.
 
 ```python
 from pal import ProteusVariable

--- a/docs/tutorials/frequency_severity_modelling.md
+++ b/docs/tutorials/frequency_severity_modelling.md
@@ -307,9 +307,9 @@ consistency across derived variables.
 
 | Class | Description |
 |-------|-------------|
-| `FrequencySeverityModel` (`from pal import FrequencySeverityModel`) | Creates compound models from freq + sev distributions |
-| `FreqSevSims` (`from pal import FreqSevSims`) | Container for event-level simulations with sim indices |
-| `StochasticScalar` (`from pal import StochasticScalar`) | Simulation-level vector returned by `aggregate()` / `occurrence()` |
+| `FrequencySeverityModel` | Creates compound models from freq + sev distributions |
+| `FreqSevSims` | Container for event-level simulations with sim indices |
+| `StochasticScalar` | Simulation-level vector returned by `aggregate()` / `occurrence()` |
 
 ## See Also
 

--- a/docs/tutorials/frequency_severity_modelling.md
+++ b/docs/tutorials/frequency_severity_modelling.md
@@ -9,11 +9,10 @@ amounts (severity).
 ```python
 import numpy as np
 
-from pal import config, set_random_seed
+from pal import FrequencySeverityModel, config, set_random_seed
 from pal.contracts import XoL
 from pal.copulas import GaussianCopula
 from pal.distributions import Gamma, LogNormal, NegBinomial, Normal, Pareto, Poisson
-from pal.frequency_severity import FrequencySeverityModel
 
 config.n_sims = 10_000
 set_random_seed(42)
@@ -308,9 +307,9 @@ consistency across derived variables.
 
 | Class | Description |
 |-------|-------------|
-| `FrequencySeverityModel` (`from pal.frequency_severity import FrequencySeverityModel`) | Creates compound models from freq + sev distributions |
-| `FreqSevSims` (`from pal.frequency_severity import FreqSevSims`) | Container for event-level simulations with sim indices |
-| `StochasticScalar` (`from pal.variables import StochasticScalar`) | Simulation-level vector returned by `aggregate()` / `occurrence()` |
+| `FrequencySeverityModel` (`from pal import FrequencySeverityModel`) | Creates compound models from freq + sev distributions |
+| `FreqSevSims` (`from pal import FreqSevSims`) | Container for event-level simulations with sim indices |
+| `StochasticScalar` (`from pal import StochasticScalar`) | Simulation-level vector returned by `aggregate()` / `occurrence()` |
 
 ## See Also
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -29,7 +29,7 @@ Create a loss variable from a LogNormal distribution:
 loss = LogNormal(mu=14, sigma=0.5).generate()
 ```
 
-This returns a `StochasticScalar` — a vector of simulated values.
+This returns a `StochasticScalar` — a vector of 10,000 simulated values.
 You can inspect it immediately:
 
 <!--pytest-codeblocks:cont-->

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -8,17 +8,19 @@ Library through a short, end-to-end example.
 ```python
 import numpy as np
 
-from pal import config, set_random_seed
+from pal import FrequencySeverityModel, config, set_random_seed
 from pal.copulas import GaussianCopula
 from pal.distributions import LogNormal, Poisson
-from pal.frequency_severity import FrequencySeverityModel
 
 config.n_sims = 10_000
 set_random_seed(42)
 ```
 
 `config.n_sims` controls how many Monte Carlo simulations are generated
-globally. `set_random_seed` makes results reproducible.
+globally. `set_random_seed` makes results reproducible. PAL's core modelling
+abstractions — `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and
+`FrequencySeverityModel` — are available directly from `pal`; domain-specific
+classes such as distributions and copulas remain in their public submodules.
 
 ## Generating Stochastic Variables
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -29,11 +29,8 @@ Create a loss variable from a LogNormal distribution:
 loss = LogNormal(mu=14, sigma=0.5).generate()
 ```
 
-This returns a `StochasticScalar`. A `StochasticScalar` represents one value
-of a quantity in each Monte Carlo simulation, so here it represents 10,000
-possible simulated loss outcomes. Arithmetic is performed scenario by scenario,
-while methods such as `mean()`, `std()` and `percentile()` summarise the
-simulated distribution.
+This returns a `StochasticScalar` — a vector of simulated values.
+You can inspect it immediately:
 
 <!--pytest-codeblocks:cont-->
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -17,10 +17,7 @@ set_random_seed(42)
 ```
 
 `config.n_sims` controls how many Monte Carlo simulations are generated
-globally. `set_random_seed` makes results reproducible. PAL's core modelling
-abstractions — `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and
-`FrequencySeverityModel` — are available directly from `pal`; domain-specific
-classes such as distributions and copulas remain in their public submodules.
+globally. `set_random_seed` makes results reproducible.
 
 ## Generating Stochastic Variables
 
@@ -32,8 +29,11 @@ Create a loss variable from a LogNormal distribution:
 loss = LogNormal(mu=14, sigma=0.5).generate()
 ```
 
-This returns a `StochasticScalar` — a vector of 10,000 simulated values.
-You can inspect it immediately:
+This returns a `StochasticScalar`. A `StochasticScalar` represents one value
+of a quantity in each Monte Carlo simulation, so here it represents 10,000
+possible simulated loss outcomes. Arithmetic is performed scenario by scenario,
+while methods such as `mean()`, `std()` and `percentile()` summarise the
+simulated distribution.
 
 <!--pytest-codeblocks:cont-->
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,10 +6,10 @@ This guide provides comprehensive examples of using the Proteus Actuarial Librar
 
 ### Basic Stochastic Variables
 
-Stochastic variables can be created with the `StochasticScalar` class from `pal.variables`:
+`StochasticScalar` is one of PAL's core top-level modelling types:
 
 ```python
-from pal.variables import StochasticScalar
+from pal import StochasticScalar
 
 # Create from array
 svariable = StochasticScalar([1, 2, 3, 4])
@@ -31,11 +31,11 @@ lognormal_var = LogNormal(mu=1, sigma=0.5).generate()
 
 ## Variable Containers
 
-Variables can be grouped into containers with the `ProteusVariable` class from `pal.variables`:
+`ProteusVariable` is also exposed directly from `pal`:
 
 ```python
+from pal import ProteusVariable
 from pal.distributions import Gamma, LogNormal
-from pal.variables import ProteusVariable
 
 # Create individual variables
 motor_losses = Gamma(alpha=2.5, theta=2).generate()
@@ -231,8 +231,8 @@ PAL provides rich type annotations using protocols for better type safety in you
 ### Using Protocol Types in Function Signatures
 
 ```python
+from pal import StochasticScalar
 from pal.types import DistributionLike, ProteusLike, VectorLike
-from pal.variables import StochasticScalar
 
 # Accept any ProteusLike container with StochasticScalar values
 def analyze_risk(variable: ProteusLike[StochasticScalar]) -> float:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@ This guide provides comprehensive examples of using the Proteus Actuarial Librar
 
 ### Basic Stochastic Variables
 
-`StochasticScalar` is one of PAL's core top-level modelling types:
+A `StochasticScalar` is a vector of simulated values:
 
 ```python
 from pal import StochasticScalar
@@ -31,7 +31,7 @@ lognormal_var = LogNormal(mu=1, sigma=0.5).generate()
 
 ## Variable Containers
 
-`ProteusVariable` is also exposed directly from `pal`:
+Variables can be grouped into containers with the `ProteusVariable` class:
 
 ```python
 from pal import ProteusVariable

--- a/examples/typecheck_exports.py
+++ b/examples/typecheck_exports.py
@@ -6,12 +6,18 @@ should rely on from the installed package.
 
 # pyright: reportUnusedImport=false
 
-from pal import config, set_default_n_sims, set_random_seed
+from pal import (
+    FreqSevSims,
+    FrequencySeverityModel,
+    ProteusVariable,
+    StochasticScalar,
+    config,
+    set_default_n_sims,
+    set_random_seed,
+)
 from pal.contracts import XoL, XoLTower
 from pal.copulas import GaussianCopula
 from pal.distributions import Gamma
-from pal.frequency_severity import FreqSevSims, FrequencySeverityModel
-from pal.variables import ProteusVariable, StochasticScalar
 
 _ = (
     config,

--- a/src/pal/AGENTS.md
+++ b/src/pal/AGENTS.md
@@ -5,10 +5,11 @@ These rules apply to changes under `src/pal/` in addition to the root `AGENTS.md
 ## Public API
 
 - Treat documented public classes, functions, methods and import paths as compatibility-sensitive.
-- PAL's top-level namespace is intentionally small. Import modelling classes and functions directly from their documented submodules: use `from pal.distributions import Gamma`, `from pal.copulas import GaussianCopula`, `from pal.frequency_severity import FrequencySeverityModel`, and the equivalent pattern for contracts, risk measures and other modelling domains. Do not teach module-qualified forms such as `distributions.Gamma(...)` or `frequency_severity.FrequencySeverityModel(...)` in user-facing code.
-- Core variable types are imported directly from `pal.variables`. Use `from pal.variables import StochasticScalar, ProteusVariable`; do not teach `stochastic_scalar.StochasticScalar` or `from pal.stochastic_scalar import StochasticScalar` as public API.
-- Do not re-export domain classes or functions from `pal.__init__`. In particular, examples should not teach `from pal import Gamma`, `XoL`, `StochasticScalar`, `GaussianCopula`, or similar shortcuts.
-- The `config` singleton and its small configuration helpers are intentional top-level conveniences; do not generalise that exception to modelling classes.
+- PAL's top-level namespace is intentionally small. The four core modelling abstractions `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and `FrequencySeverityModel` are deliberate top-level exports and should normally be imported with `from pal import ...`.
+- Other modelling classes and functions are imported directly from their documented submodules: use `from pal.distributions import Gamma`, `from pal.copulas import GaussianCopula`, and the equivalent pattern for contracts, risk measures and other modelling domains. Do not teach module-qualified forms such as `distributions.Gamma(...)` in user-facing code.
+- `ProteusVariable` and `StochasticScalar` also remain available from `pal.variables`, and frequency-severity classes remain available from `pal.frequency_severity`, for compatibility and discoverability. Prefer the top-level imports in new user-facing examples.
+- Do not generalise the four core-class exports into a flattened package API. In particular, examples should not teach `from pal import Gamma`, `XoL`, `GaussianCopula`, or similar domain shortcuts.
+- The `config` singleton and its small configuration helpers are also intentional top-level conveniences.
 - User-facing docstrings should explain actuarial/statistical behaviour, not internal backend mechanics.
 - Prefer terminology a PAL user would recognise. For example, `StochasticScalar.mean()` takes the mean across simulations; users do not need implementation language such as "backend ndarray".
 - Keep signatures, type annotations and docstrings mutually consistent.

--- a/src/pal/__init__.py
+++ b/src/pal/__init__.py
@@ -59,13 +59,12 @@ for _distribution_name, _distribution in {
 }.items():
     setattr(distributions, _distribution_name, _distribution)
 
-# ``copulas`` historically imports these two classes from the package root, and
-# they are also part of PAL's intentionally small top-level public API.
-from . import copulas as copulas  # noqa: E402
-
+# ``copulas`` historically imports the core variable classes from the package
+# root. They are now also part of PAL's intentionally small top-level public API.
 # Import the public module namespaces explicitly so ``import pal; pal.contracts``
 # and ``from pal import contracts`` are both reliable and discoverable.
 from . import contracts as contracts  # noqa: E402
+from . import copulas as copulas  # noqa: E402
 from . import couplings as couplings  # noqa: E402
 from . import frequency_severity as frequency_severity  # noqa: E402
 from . import maths as maths  # noqa: E402

--- a/src/pal/__init__.py
+++ b/src/pal/__init__.py
@@ -29,8 +29,8 @@ from .multivariate_distributions import MultivariateDistributionBase as _Multiva
 from .multivariate_distributions import MultivariateNormal as _MultivariateNormal
 from .multivariate_distributions import MultivariateStudentsT as _MultivariateStudentsT
 from .multivariate_distributions import Wishart as _Wishart
-from .stochastic_scalar import StochasticScalar as _StochasticScalar
-from .variables import ProteusVariable as _ProteusVariable
+from .stochastic_scalar import StochasticScalar
+from .variables import ProteusVariable
 
 # Empirical and HyperExponential have vector-valued parameters and are
 # implemented in separate modules. Expose them through the standard
@@ -59,14 +59,9 @@ for _distribution_name, _distribution in {
 }.items():
     setattr(distributions, _distribution_name, _distribution)
 
-# ``copulas`` historically imports these two classes from the package root.
-# Make them available only while the module initialises, then remove them again
-# so users cannot rely on the old top-level shortcuts.
-ProteusVariable = _ProteusVariable
-StochasticScalar = _StochasticScalar
+# ``copulas`` historically imports these two classes from the package root, and
+# they are also part of PAL's intentionally small top-level public API.
 from . import copulas as copulas  # noqa: E402
-
-del ProteusVariable, StochasticScalar
 
 # Import the public module namespaces explicitly so ``import pal; pal.contracts``
 # and ``from pal import contracts`` are both reliable and discoverable.
@@ -78,9 +73,11 @@ from . import multivariate_distributions as multivariate_distributions  # noqa: 
 from . import risk_measures as risk_measures  # noqa: E402
 from . import stats as stats  # noqa: E402
 from . import variables as variables  # noqa: E402
+from .frequency_severity import FreqSevSims, FrequencySeverityModel  # noqa: E402
 
 # StochasticScalar is conceptually a PAL variable, even though its implementation
-# lives in a dedicated module. Make ``pal.variables`` its canonical public home.
+# lives in a dedicated module. Make ``pal.variables`` its canonical module home
+# as well as exposing it as a top-level core type.
 if "StochasticScalar" not in variables.__all__:
     variables.__all__.append("StochasticScalar")
 
@@ -89,6 +86,10 @@ if "StochasticScalar" not in variables.__all__:
 from . import api as api  # noqa: E402
 
 __all__ = [
+    "FreqSevSims",
+    "FrequencySeverityModel",
+    "ProteusVariable",
+    "StochasticScalar",
     "api",
     "config",
     "contracts",

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -3,8 +3,12 @@
 import pal
 
 
-def test_pal_top_level_namespace_is_module_oriented() -> None:
+def test_pal_top_level_namespace_exposes_core_types_and_modules() -> None:
     from pal import (
+        FreqSevSims,
+        FrequencySeverityModel,
+        ProteusVariable,
+        StochasticScalar,
         config,
         contracts,
         copulas,
@@ -20,6 +24,10 @@ def test_pal_top_level_namespace_is_module_oriented() -> None:
         variables,
     )
 
+    assert ProteusVariable is pal.variables.ProteusVariable
+    assert StochasticScalar is pal.variables.StochasticScalar
+    assert FreqSevSims is pal.frequency_severity.FreqSevSims
+    assert FrequencySeverityModel is pal.frequency_severity.FrequencySeverityModel
     assert config is not None
     assert distributions is not None
     assert contracts is not None
@@ -36,20 +44,20 @@ def test_pal_top_level_namespace_is_module_oriented() -> None:
     assert "stochastic_scalar" not in pal.__all__
 
 
-def test_variable_types_are_imported_from_pal_variables() -> None:
+def test_core_types_remain_available_from_domain_modules() -> None:
+    from pal.frequency_severity import FreqSevSims, FrequencySeverityModel
     from pal.variables import ProteusVariable, StochasticScalar
 
-    assert ProteusVariable is pal.variables.ProteusVariable
-    assert StochasticScalar is pal.variables.StochasticScalar
+    assert ProteusVariable is pal.ProteusVariable
+    assert StochasticScalar is pal.StochasticScalar
+    assert FreqSevSims is pal.FreqSevSims
+    assert FrequencySeverityModel is pal.FrequencySeverityModel
 
 
-def test_domain_objects_are_not_reexported_at_top_level() -> None:
+def test_other_domain_objects_are_not_reexported_at_top_level() -> None:
     for name in (
         "Gamma",
         "GaussianCopula",
-        "FreqSevSims",
-        "ProteusVariable",
-        "StochasticScalar",
         "XoL",
         "XoLTower",
     ):

--- a/tests/test_public_import_style.py
+++ b/tests/test_public_import_style.py
@@ -17,12 +17,12 @@ _ALLOWED_TOP_LEVEL_IMPORTS = {
     "set_random_seed",
 }
 
-_TOP_LEVEL_IMPORT = re.compile(r"from\s+pal\s+import\s+(\([^)]*\)|[^\n]+)", re.MULTILINE | re.DOTALL)
+_TOP_LEVEL_IMPORT = re.compile(r"^\s*from\s+pal\s+import\s+(\([^)]*\)|[^\n]+)", re.MULTILINE)
 _DOMAIN_MODULE_IMPORT = re.compile(
     r"^\s*import\s+pal\.(?:contracts|copulas|distributions|frequency_severity|multivariate_distributions|risk_measures|variables)\b",
     re.MULTILINE,
 )
-_FORBIDDEN_IMPLEMENTATION_IMPORT = re.compile(r"from\s+pal\.stochastic_scalar\s+import\s+")
+_FORBIDDEN_IMPLEMENTATION_IMPORT = re.compile(r"^\s*from\s+pal\.stochastic_scalar\s+import\s+", re.MULTILINE)
 
 
 def _user_facing_files() -> list[Path]:

--- a/tests/test_public_import_style.py
+++ b/tests/test_public_import_style.py
@@ -7,6 +7,10 @@ from pathlib import Path
 ROOT = Path(__file__).parents[1]
 
 _ALLOWED_TOP_LEVEL_IMPORTS = {
+    "FreqSevSims",
+    "FrequencySeverityModel",
+    "ProteusVariable",
+    "StochasticScalar",
     "api",
     "config",
     "set_default_n_sims",
@@ -73,6 +77,6 @@ def test_user_examples_use_documented_pal_imports() -> None:
             )
 
         if _FORBIDDEN_IMPLEMENTATION_IMPORT.search(text) or "stochastic_scalar.StochasticScalar" in text:
-            violations.append(f"{relative}: import StochasticScalar with `from pal.variables import StochasticScalar`")
+            violations.append(f"{relative}: use the public `StochasticScalar` import path")
 
     assert not violations, "\n" + "\n".join(violations)

--- a/tests/test_public_import_style.py
+++ b/tests/test_public_import_style.py
@@ -56,6 +56,24 @@ def _normalise_import_names(import_text: str) -> set[str]:
     return names
 
 
+def test_top_level_import_regex_matches_parenthesized_multiline_imports() -> None:
+    text = """from pal import (
+    FrequencySeverityModel,
+    ProteusVariable,
+    StochasticScalar,
+)
+"""
+
+    match = _TOP_LEVEL_IMPORT.search(text)
+
+    assert match is not None
+    assert _normalise_import_names(match.group(1)) == {
+        "FrequencySeverityModel",
+        "ProteusVariable",
+        "StochasticScalar",
+    }
+
+
 def test_user_examples_use_documented_pal_imports() -> None:
     violations: list[str] = []
 


### PR DESCRIPTION
## Summary

- expose `ProteusVariable`, `StochasticScalar`, `FreqSevSims`, and `FrequencySeverityModel` from `pal`
- retain their existing submodule import paths for compatibility
- update user-facing examples to use the top-level imports without making import-path design part of the conceptual documentation
- update agent guidance and tests so future examples follow the same public API
- keep documentation code blocks covered by the existing `pytest --codeblocks` CI test matrix

## Documentation approach

This PR deliberately keeps the documentation changes narrow. Existing explanations should continue to describe what PAL objects represent and how users work with them; the import-path change should normally appear only in code. Existing prose is preserved unless a change is required for correctness or clarity.

## Testing

- package export identity tests cover the four top-level classes
- import-style guardrails cover user-facing examples, including parenthesized multiline imports
- existing CI runs documentation code blocks via `pytest ... --codeblocks`
