### PR TITLE
Restore tutorial charts and guard against accidental removal

### DIFF
--- a/docs/tutorials/coupling_groups_and_copulas.md
+++ b/docs/tutorials/coupling_groups_and_copulas.md
@@ -142,6 +142,24 @@ GaussianCopula([[1.0, 0.8], [0.8, 1.0]]).apply([x, y])
 np.corrcoef(x.ranks, y.ranks)[0, 1]
 ```
 
+### Scatter Plots — Rank Space
+
+The best way to understand how copulas differ is to plot the variables in
+**rank space** (plotting the ranks rather than the raw values). This removes
+the effect of the marginal distributions and isolates the dependency
+structure.
+
+```{only} html
+![Copula dependency structures in rank space](../_static/generated/copula_scatter_plots.svg)
+```
+
+- **Independent**: uniform scatter with no pattern
+- **Gaussian**: elliptical concentration along the diagonal
+- **Gumbel**: strong clustering in the upper-right corner (upper tail)
+- **Clayton**: strong clustering in the lower-left corner (lower tail)
+- **Student's T**: similar to Gaussian but with heavier concentration in
+  both corners (both tails)
+
 PAL can also generate all pairwise scatter plots directly from a
 `ProteusVariable`:
 
@@ -152,6 +170,16 @@ dependency = ProteusVariable("variable", {"X": x, "Y": y})
 dependency.rank_scatter_plot(title="Dependency in rank space").show()
 dependency.value_scatter_plot(title="Dependency in value space").show()
 ```
+
+```{only} html
+![Pairwise dependency in rank space](../_static/generated/copula_rank_scatter.svg)
+
+![Pairwise dependency in value space](../_static/generated/copula_value_scatter.svg)
+```
+
+For multivariate variables these methods plot every unordered pair. By default
+pairs are shown in subplots; pass `frames=True` to show one pair at a time with
+a Plotly slider.
 
 ## 3. Variable Reordering
 

--- a/tests/test_documentation_charts.py
+++ b/tests/test_documentation_charts.py
@@ -8,7 +8,6 @@ remove the charts while leaving the SVG files orphaned.
 
 from pathlib import Path
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _GENERATED = _REPO_ROOT / "docs" / "source" / "_static" / "generated"
 

--- a/tests/test_documentation_charts.py
+++ b/tests/test_documentation_charts.py
@@ -12,9 +12,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _GENERATED = _REPO_ROOT / "docs" / "source" / "_static" / "generated"
 
 _EXPECTED_CHARTS = {
-    "docs/tutorials/getting_started.md": (
-        "getting_started_aggregate_cdf.svg",
-    ),
+    "docs/tutorials/getting_started.md": ("getting_started_aggregate_cdf.svg",),
     "docs/tutorials/distributions_guide.md": (
         "distributions_guide_cdf.svg",
         "distributions_guide_histogram.svg",

--- a/tests/test_documentation_charts.py
+++ b/tests/test_documentation_charts.py
@@ -1,0 +1,49 @@
+"""Regression tests for committed tutorial chart assets.
+
+The documentation deliberately uses committed SVGs so Read the Docs does not
+need to generate Plotly images during the build.  Keep both the assets and their
+embeds protected: a broad documentation rewrite should not be able to silently
+remove the charts while leaving the SVG files orphaned.
+"""
+
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_GENERATED = _REPO_ROOT / "docs" / "source" / "_static" / "generated"
+
+_EXPECTED_CHARTS = {
+    "docs/tutorials/getting_started.md": (
+        "getting_started_aggregate_cdf.svg",
+    ),
+    "docs/tutorials/distributions_guide.md": (
+        "distributions_guide_cdf.svg",
+        "distributions_guide_histogram.svg",
+    ),
+    "docs/tutorials/coupling_groups_and_copulas.md": (
+        "copula_scatter_plots.svg",
+        "copula_rank_scatter.svg",
+        "copula_value_scatter.svg",
+    ),
+    "docs/tutorials/risk_measures_and_allocation.md": (
+        "risk_measure_weights.svg",
+        "xol_pricing_curve.svg",
+    ),
+}
+
+
+def test_documentation_chart_assets_are_committed_and_embedded() -> None:
+    """Every intended tutorial chart must exist and remain embedded."""
+    for tutorial_path, chart_names in _EXPECTED_CHARTS.items():
+        tutorial = _REPO_ROOT / tutorial_path
+        content = tutorial.read_text(encoding="utf-8")
+
+        for chart_name in chart_names:
+            asset = _GENERATED / chart_name
+            assert asset.is_file(), f"Missing committed chart asset: {asset}"
+            assert asset.stat().st_size > 0, f"Empty committed chart asset: {asset}"
+            assert chart_name in content, (
+                f"{tutorial_path} no longer embeds {chart_name}. "
+                "If this chart is intentionally removed, update the regression "
+                "test and remove the orphaned generated asset in the same change."
+            )


### PR DESCRIPTION
## Summary

Restores the copula visualisations that were accidentally removed from the coupling/copulas tutorial in PR #116, while preserving the newer explicit submodule import style.

The committed SVG assets themselves were not lost: the regression was the removal of the Markdown embeds and accompanying explanatory section.

## Prevention

Adds a regression test covering every committed generated tutorial chart. The test verifies that:

- each expected SVG remains committed and non-empty; and
- each chart remains embedded in its intended tutorial.

This means a future broad documentation rewrite cannot silently strip the charts while leaving orphaned assets behind.

## Charts covered

- Getting started aggregate CDF
- Distribution CDF and histogram
- Copula comparison, rank scatter and value scatter
- Risk-measure weights
- XoL pricing curve

## Root cause

PR #116 (`Add runtime API discovery and explicit PAL submodule imports`) changed all tutorial files and unintentionally deleted the copula rank-space visualisation subsection and all three copula image embeds. The other current chart embeds remain present; the live risk-measure and XoL documentation is still rendering those images correctly.
